### PR TITLE
fix: rust-toolchain pinned

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "1.88.0"
-
+channel = "1.91.0"


### PR DESCRIPTION
Pinning the specific rust version to avoid this:

```shell
$ cargo run
...
error: rustc 1.87.0 is not supported by the following package:
  home@0.5.12 requires rustc 1.88
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.87.0
```